### PR TITLE
Backport a few patches from the SARS-CoV-2 branch #SWAT4HCLS

### DIFF
--- a/scheduled_bots/logger/bot_log_parser.py
+++ b/scheduled_bots/logger/bot_log_parser.py
@@ -167,7 +167,7 @@ def format_ManualInterventionReqException(s):
     if "More than one WD item has the same property value" in s:
         pid = s.split("Property: ")[1].split(",")[0].strip()
         qids = literal_eval(s.split("items affected: ")[1])
-        urls = ['<a href="https://www.wikidata.org/wiki/Q{}#{}">Q{}</a>'.format(x, pid, x) for x in qids]
+        urls = ['<a href="https://www.wikidata.org/wiki/{}#{}">{}</a>'.format(x, pid, x) for x in qids]
         return "More than one WD item has the same property value: {}".format(", ".join(urls))
     elif "does not match provided core ID" in s:
         qid = s.split("Retrieved item (")[1].split(")")[0]

--- a/scheduled_bots/wikipathways/bot.py
+++ b/scheduled_bots/wikipathways/bot.py
@@ -139,7 +139,6 @@ def main(retrieved, fast_run, write):
     wp_query = """prefix dcterm: <http://purl.org/dc/terms/>
             prefix wp: <http://vocabularies.wikipathways.org/wp#>
             SELECT DISTINCT ?wpid WHERE {
-              VALUES ?wpid { "WP4846"^^xsd:string }
               ?s rdf:type <http://vocabularies.wikipathways.org/wp#Pathway> ;
                  dcterm:identifier ?wpid ;
                  ?p <http://vocabularies.wikipathways.org/wp#Curation:AnalysisCollection> ;


### PR DESCRIPTION
These features are now found in the monthly release of curated WikiPathways and not limited to the COVID-19 portal:

1. support for proteins with (only) a Wikidata identifier (needed for virus proteins)
2. support for macromolecular complexes

And there is a bug fix for the error reporting: https://github.com/SuLab/scheduled-bots/commit/fc26b17b568751e598ee71cb0689603908de13c8