### PR TITLE
Support both author identifiers.org IRIs

### DIFF
--- a/scheduled_bots/wikipathways/bot.py
+++ b/scheduled_bots/wikipathways/bot.py
@@ -253,7 +253,9 @@ def run_one(pathway_id, retrieved, fast_run, write, login, temp):
                 PREFIX wp:    <http://vocabularies.wikipathways.org/wp#>
                 SELECT ?author ?authorName ?authorHomepage ?authorQIRI
                 WHERE {
-                  <http://identifiers.org/wikipathways/""" + pathway_id + """> dc:creator ?author .
+                  { <http://identifiers.org/wikipathways/""" + pathway_id + """> dc:creator ?author . }
+                  UNION
+                  { <https://identifiers.org/wikipathways/""" + pathway_id + """> dc:creator ?author . }
                   ?author a                    foaf:Person ;
                   foaf:name            ?authorName ;
                   foaf:homepage            ?authorHomepage .


### PR DESCRIPTION
Support both for now, until we're 100% sure the authors RDF is generated properly

Patch from https://github.com/SuLab/scheduled-bots/pull/75 but now on `main`